### PR TITLE
Add kitchensink page

### DIFF
--- a/src/pages/kitchensink.js
+++ b/src/pages/kitchensink.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import Layout from "../components/Layout";
+
+export default () => (
+  <Layout>
+    Hello world
+  </Layout>
+)


### PR DESCRIPTION
Why:

* We need a place to see all the individual components before the pages are ready;

These changes address the need by:

* Adding an new page named `kitchensink`;