### PR TITLE
Fix link display so underline stays inside the content-box

### DIFF
--- a/src/components/Link/index.module.css
+++ b/src/components/Link/index.module.css
@@ -3,7 +3,10 @@
 .root {
   position: relative;
 
+  padding-bottom: $size-12;
+
   color: $color-blue;
+
   font-size: $size-26;
   line-height: $size-36;
   text-decoration: none;
@@ -11,8 +14,9 @@
 
 .underline {
   position: absolute;
-  bottom: -$size-12;
+  bottom: 0;
   left: 0;
+
   width: 100%;
   height: 2px;
 


### PR DESCRIPTION
The design expects the underline to be part of the content box. Check the stats section for an example. 

This fixes uses padding and the display mode so the link component takes the full space as needed.