### PR TITLE
Fix FOUC on Firefox

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -19,6 +19,9 @@ export default class MyDocument extends Document {
       <Html lang="pt">
         <Head />
         <body>
+          {/** Avoid FOUC with this hack on firefox */}
+          <script>0</script>
+
           <div dangerouslySetInnerHTML={{ __html: this.props.spriteContent }} />
           <Main />
           <NextScript />


### PR DESCRIPTION
On Firefox browsers with a slow network, the whole website appears without CSS during a fraction of a second. That's ugly.

According to a bugzilla that I forgot to link and it's too late for that, they recommend adding a dummy script tag right after the opening of the body tag. With that, it magically fixes itself.